### PR TITLE
Make lazysodium-java work in a stand-alone spring boot jar

### DIFF
--- a/src/main/java/co/libly/resourceloader/ResourceLoader.java
+++ b/src/main/java/co/libly/resourceloader/ResourceLoader.java
@@ -76,8 +76,15 @@ public class ResourceLoader {
         // Create the required directories.
         mainTempDir.mkdirs();
 
+
         // Is the user loading this in a JAR?
         URL jarUrl = getThisJarPath(outsideClass);
+
+        if (jarUrl.toString().startsWith("jar")) {
+            String[] jarinjar = jarUrl.toString().split("!");
+            jarUrl = doubleExtract(jarinjar);
+        }
+
         if (isJarFile(jarUrl)) {
             // If so the get the file/directory
             // from a JAR
@@ -92,6 +99,17 @@ public class ResourceLoader {
         // If not then get the file/directory
         // straight from the file system
         return getFileFromFileSystem(relativePath, mainTempDir);
+    }
+
+    public URL doubleExtract(String[] jarinjar) throws IOException, URISyntaxException {
+        URL outerJar = new URL(jarinjar[0] + "!/");
+        String innerJar = jarinjar[1];
+
+        File tempDir = createMainTempDirectory();
+        tempDir.mkdirs();
+
+        File innerJarFile = getFileFromJar(outerJar, tempDir,innerJar);
+        return innerJarFile.toURI().toURL();
     }
 
     private boolean isJarFile(URL jarUrl) {


### PR DESCRIPTION
So that a spring boot application with a dependency to `lazysodium-java` can be executed stand-alone as a fat jar. Such as:

```sh
java -jar app.jar
```

For example, the main spring boot fat `app.jar` first extracts `lazysodium-java-4.3.0.jar` and is then followed by the extraction of `libsodium.so`  from within `lazysodium-java-4.3.0.jar`