### PR TITLE
Load file resource when used in a modular runtime image application.

### DIFF
--- a/src/main/java/com/goterl/resourceloader/ResourceLoader.java
+++ b/src/main/java/com/goterl/resourceloader/ResourceLoader.java
@@ -58,7 +58,7 @@ public class ResourceLoader {
      * Copies a file into a temporary directory regardless of
      * if it is in a JAR or not.
      * @param relativePath A relative path to a file or directory
-     *                     relative to the resources folder.
+     *                     relative to the resource folder.
      * @return The file or directory you want to load.
      * @throws IOException If at any point processing of the resource file fails.
      * @throws URISyntaxException If cannot find the resource file.
@@ -73,7 +73,8 @@ public class ResourceLoader {
 
         // Check if we can access the resource using the classloader.
         // This works for Java module.
-        File extracted = extractUsingClassLoader(mainTempDir, relativePath);
+        File extracted;
+        extracted = extractUsingClassLoader(mainTempDir, relativePath);
         if (extracted != null) {
             return extracted;
         }
@@ -131,7 +132,7 @@ public class ResourceLoader {
         // JrtFileSystem where Path are implemented with JrtPath, but, JrtPath cannot be converted to a File using.
         // toFile() It is not supported and throws NotSupportedOperation exception if called.
 
-        // FIXME: Does it have to be relative?
+        // It should already be relative but just in case.
         if (relativePath.charAt(0) == '/') {
             is = cl.getResourceAsStream(relativePath.substring(1));
         } else {

--- a/src/main/java/com/goterl/resourceloader/ResourceLoader.java
+++ b/src/main/java/com/goterl/resourceloader/ResourceLoader.java
@@ -15,7 +15,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.channels.FileChannel;


### PR DESCRIPTION
This PR adds the ability for the library to load file resource (not directory though) when it is run in a modular runtime image application that was created with JLink, using this [plugin](https://github.com/beryx/badass-jlink-plugin).

Because this library is not modular, it is merged into a single jar and ends up in the application main module. The relative path to resources stay the same but since they are now packaged within the "modules" file in the image, you have to use `ClassLoader.getResourceAsStream`.

The changes in this PR should not change the way this library behaves. All existing tests are passing.

You can find an example of a modular runtime image app using it at [example](https://github.com/renaudberube/resource-loader-modular-example)